### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/VSLangProj.Shared/VSLangProj.Shared.csproj
+++ b/VSLangProj.Shared/VSLangProj.Shared.csproj
@@ -21,7 +21,16 @@
         <PackageReleaseNotes>v2.0.0 updates to newest version of Microsoft's libraries. No changes in code.
 v2.1.0 add support for async load packages</PackageReleaseNotes>
         <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DocumentationFile>bin\Debug\net472\Dzonny.VSLangProj.Shared.dll.xml</DocumentationFile>
     </PropertyGroup>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
